### PR TITLE
fix: JWT field name mismatch - use org_id instead of organizationId (closes #120)

### DIFF
--- a/apps/web/app/api/v1/assessments/route.ts
+++ b/apps/web/app/api/v1/assessments/route.ts
@@ -50,7 +50,10 @@ function generateJWTFromSession(session: any): string {
     sub: session.user.id,
     email: session.user.email || "",
     role: session.user.role,
-    organizationId: session.user.organizationId,
+    // IMPORTANT: Backend expects snake_case 'org_id', not camelCase 'organizationId'
+    // Session uses organizationId (TypeScript convention), but JWT must use org_id (Python convention)
+    // See: apps/api/app/core/auth.py:177, apps/web/types/next-auth.d.ts:39
+    org_id: session.user.organizationId,
     name: session.user.name || null,
     iat: Math.floor(Date.now() / 1000),
     exp: Math.floor(Date.now() / 1000) + (30 * 60), // 30 minutes

--- a/apps/web/app/api/v1/documents/route.ts
+++ b/apps/web/app/api/v1/documents/route.ts
@@ -52,7 +52,10 @@ function generateJWTFromSession(session: any): string {
     sub: session.user.id,
     email: session.user.email || "",
     role: session.user.role,
-    organizationId: session.user.organizationId,
+    // IMPORTANT: Backend expects snake_case 'org_id', not camelCase 'organizationId'
+    // Session uses organizationId (TypeScript convention), but JWT must use org_id (Python convention)
+    // See: apps/api/app/core/auth.py:177, apps/web/types/next-auth.d.ts:39
+    org_id: session.user.organizationId,
     name: session.user.name || null,
     iat: Math.floor(Date.now() / 1000),
     exp: Math.floor(Date.now() / 1000) + (30 * 60), // 30 minutes

--- a/apps/web/app/api/v1/workflows/route.ts
+++ b/apps/web/app/api/v1/workflows/route.ts
@@ -50,7 +50,10 @@ function generateJWTFromSession(session: any): string {
     sub: session.user.id,
     email: session.user.email || "",
     role: session.user.role,
-    organizationId: session.user.organizationId,
+    // IMPORTANT: Backend expects snake_case 'org_id', not camelCase 'organizationId'
+    // Session uses organizationId (TypeScript convention), but JWT must use org_id (Python convention)
+    // See: apps/api/app/core/auth.py:177, apps/web/types/next-auth.d.ts:39
+    org_id: session.user.organizationId,
     name: session.user.name || null,
     iat: Math.floor(Date.now() / 1000),
     exp: Math.floor(Date.now() / 1000) + (30 * 60), // 30 minutes


### PR DESCRIPTION
## Summary

Fix critical authentication bug where JWT field name mismatch prevents workflow creation, document upload, and assessment creation in production. The frontend API proxy routes generate JWT tokens with `organizationId` (camelCase) but the backend expects `org_id` (snake_case), causing all authenticated requests to fail with 401 Unauthorized.

## Root Cause

**Naming Convention Mapping Bug:**
- Frontend session uses `organizationId` (TypeScript camelCase convention)
- Backend expects `org_id` in JWT payload (Python snake_case convention)
- API proxy routes incorrectly used `organizationId` in JWT payload instead of `org_id`

## Changes

**Fixed Files:**
- `apps/web/app/api/v1/workflows/route.ts:56` - Changed `organizationId` → `org_id`
- `apps/web/app/api/v1/documents/route.ts:58` - Changed `organizationId` → `org_id`
- `apps/web/app/api/v1/assessments/route.ts:56` - Changed `organizationId` → `org_id`

**Documentation:**
- Added inline comments in all three files explaining the naming convention mapping
- References to backend validation code and type definitions

## Acceptance Criteria

- [x] JWT payload in workflows route uses `org_id` (not `organizationId`)
- [x] JWT payload in documents route uses `org_id` (not `organizationId`)
- [x] JWT payload in assessments route uses `org_id` (not `organizationId`)
- [x] Inline comments added explaining naming convention mapping
- [x] All instances verified with grep (no `organizationId:` remains in JWT payloads)
- [x] Code committed with conventional commit format
- [ ] Code deployed to Vercel production (auto-deploy on merge)
- [ ] Manual test: Create workflow as test@qteria.com succeeds
- [ ] Manual test: Upload document succeeds
- [ ] Manual test: Start assessment succeeds
- [ ] Railway logs show no new "missing_required_fields" errors

## Testing Plan

**Manual Testing (Post-Deploy):**
1. Deploy to Vercel production (auto-deploy on merge to main)
2. Login to https://qteria.vercel.app as test@qteria.com
3. Navigate to workflow creation page
4. Fill out workflow form and submit
5. Expected: Success message, workflow created (not "session expired" error)
6. Upload PDF document to workflow bucket
7. Expected: Document uploaded successfully
8. Start assessment with uploaded documents
9. Expected: Assessment created with status "pending"
10. Check Railway logs: No "missing_required_fields" audit events

## Impact

**Severity:** 🔴 Critical - Blocks core user journey

**Fixed Endpoints:**
- POST /api/v1/workflows (Step 1: Create Workflow)
- POST /api/v1/documents (Step 2: Upload Documents)
- POST /api/v1/assessments (Step 3: Start Assessment)

**Before Fix:**
- All authenticated requests returned 401 Unauthorized
- Frontend displayed "Your session has expired. Please log in again."
- Backend audit logs showed "missing_required_fields" errors

**After Fix:**
- JWT token includes correct `org_id` field
- Backend validation passes
- Workflows, documents, and assessments can be created successfully

## References

**Backend API Contract:**
- apps/api/app/core/auth.py:177 - Backend expects `org_id` field

**Frontend Type Definitions:**
- apps/web/types/next-auth.d.ts:39 - JWT type documents `org_id`
- apps/web/lib/auth-config-base.ts:77 - Auth.js JWT callback uses `org_id`

**Issue:**
- Closes #120

---

**Estimated Resolution Time:** <5 minutes after merge (Vercel auto-deploy + manual testing)