### PR TITLE
fix: Make CriteriaResponse.applies_to_bucket_ids Optional (closes #122)

### DIFF
--- a/apps/api/app/schemas/workflow.py
+++ b/apps/api/app/schemas/workflow.py
@@ -198,7 +198,7 @@ class CriteriaResponse(BaseModel):
     id: UUID
     name: str
     description: Optional[str]
-    applies_to_bucket_ids: List[UUID]  # Converted from indexes to actual UUIDs
+    applies_to_bucket_ids: Optional[List[UUID]] = None  # None = applies to all buckets
     order_index: int
 
     class Config:
@@ -371,9 +371,9 @@ class CriteriaUpdate(BaseModel):
         max_length=2000,
         description="Detailed description of validation rule for AI context",
     )
-    applies_to_bucket_ids: List[UUID] = Field(
-        default_factory=list,
-        description="Bucket UUIDs this criteria applies to (empty = applies to all buckets)",
+    applies_to_bucket_ids: Optional[List[UUID]] = Field(
+        default=None,
+        description="Bucket UUIDs this criteria applies to (None = applies to all buckets)",
         examples=[],
     )
     order_index: int = Field(


### PR DESCRIPTION
## Summary

Fixes Pydantic ValidationError that caused 500 Internal Server Error when creating workflows with criteria applying to all buckets. The issue was a schema mismatch: database allows `applies_to_bucket_ids=None` (meaning applies to ALL buckets), but Pydantic response schema expected a non-nullable list.

## Problem

**Symptom:** Workflow creation succeeded in database but failed during response serialization with 500 error.

**Root Cause:** Schema mismatch between database model and Pydantic response schema:
- Database model: `applies_to_bucket_ids = Column(ARRAY(UUID), nullable=True)` - `None` means applies to all buckets
- Pydantic CriteriaResponse: `applies_to_bucket_ids: List[UUID]` - Expected list, got `None` → ValidationError

**Evidence from logs:**
```
INFO: workflow_created  ✅ Workflow created in database
ERROR: workflow_creation_error  ❌ Pydantic validation failed during serialization
500 Internal Server Error
```

## Changes

### 1. CriteriaResponse Schema (`apps/api/app/schemas/workflow.py:201`)
```diff
- applies_to_bucket_ids: List[UUID]  # ❌ NOT Optional - expects List, gets None
+ applies_to_bucket_ids: Optional[List[UUID]] = None  # ✅ Matches database nullable column
```

### 2. CriteriaUpdate Schema (`apps/api/app/schemas/workflow.py:374`)
```diff
- applies_to_bucket_ids: List[UUID] = Field(default_factory=list, ...)
+ applies_to_bucket_ids: Optional[List[UUID]] = Field(default=None, ...)
```
**Rationale:** Consistency - clearer semantics: `None` = all buckets, `[]` = no buckets (edge case)

### 3. Test Updates (`apps/api/tests/test_workflow_api.py`)
- **Updated** `test_create_workflow_criteria_applies_to_all_buckets`: Assert `is None` instead of `== []`
- **Added** `test_create_workflow_criteria_applies_to_specific_buckets`: Verify specific bucket references work correctly

## Testing

**Unit Tests:**
```
✅ test_create_workflow_criteria_applies_to_all_buckets - PASSED
✅ test_create_workflow_criteria_applies_to_specific_buckets - PASSED (new)
✅ Full workflow test suite: 34/35 passed
```

Note: 1 pre-existing test failure (`test_create_workflow_duplicate_bucket_names`) unrelated to this fix - already failing on `main` branch.

**Manual Testing Required (Production):**
1. Login to https://qteria.vercel.app
2. Create workflow with criteria applying to all buckets (empty `applies_to_bucket_ids`)
3. Expected: 201 Created, workflow visible in list
4. Create workflow with criteria applying to specific bucket (index [0])
5. Expected: 201 Created, criteria shows correct bucket UUID

## Impact Assessment

**Severity:** 🔴 Critical - Blocks core user journey (Step 1: Create Workflow)

**User Impact:**
- **Before:** 100% of workflow creation attempts failed when criteria had empty `applies_to_bucket_ids`
- **After:** All workflow creation scenarios work correctly

**Breaking Changes:** None
- Frontend already handles both `null` and empty array for `applies_to_bucket_ids`
- Database unchanged (already supports NULL values)
- Backward compatible with existing workflows

## Acceptance Criteria

- [x] `CriteriaResponse.applies_to_bucket_ids` is `Optional[List[UUID]] = None`
- [x] `CriteriaUpdate.applies_to_bucket_ids` is `Optional[List[UUID]] = Field(default=None, ...)`
- [x] Workflow creation with criteria applying to all buckets succeeds (201)
- [x] Response includes `applies_to_bucket_ids: null` (JSON null, not empty array)
- [x] Unit tests added for both None and specific bucket scenarios
- [ ] Manual testing confirms production workflow creation succeeds (post-deployment)

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)