### PR TITLE
fix: Seed test database to resolve workflow creation IntegrityError (closes #148)

### DIFF
--- a/apps/api/scripts/seed_test_data.py
+++ b/apps/api/scripts/seed_test_data.py
@@ -4,7 +4,7 @@ Seed test data for pytest test suite.
 
 This script populates the qteria-test database with:
 - 2 test organizations (Org A, Org B)
-- 4 test users (process managers and admins for each org)
+- 6 test users (admins, process managers, and project handlers for each org)
 
 Run this script ONCE after creating the test database schema.
 
@@ -32,6 +32,8 @@ from tests.conftest import (
     TEST_USER_B_ID,
     TEST_USER_A_PM_ID,
     TEST_USER_B_PM_ID,
+    TEST_USER_A_PH_ID,
+    TEST_USER_B_PH_ID,
 )
 
 # Convert string UUIDs to UUID objects
@@ -41,6 +43,8 @@ USER_A_UUID = UUID(TEST_USER_A_ID)
 USER_B_UUID = UUID(TEST_USER_B_ID)
 USER_A_PM_UUID = UUID(TEST_USER_A_PM_ID)
 USER_B_PM_UUID = UUID(TEST_USER_B_PM_ID)
+USER_A_PH_UUID = UUID(TEST_USER_A_PH_ID)
+USER_B_PH_UUID = UUID(TEST_USER_B_PH_ID)
 
 
 def seed_test_data():
@@ -124,14 +128,32 @@ def seed_test_data():
             role=UserRole.PROCESS_MANAGER,
         )
 
-        db.add_all([user_a_admin, user_a_pm, user_b_admin, user_b_pm])
+        user_a_ph = User(
+            id=USER_A_PH_UUID,
+            organization_id=ORG_A_UUID,
+            email="ph@test-org-a.com",
+            name="Project Handler A",
+            role=UserRole.PROJECT_HANDLER,
+        )
+
+        user_b_ph = User(
+            id=USER_B_PH_UUID,
+            organization_id=ORG_B_UUID,
+            email="ph@test-org-b.com",
+            name="Project Handler B",
+            role=UserRole.PROJECT_HANDLER,
+        )
+
+        db.add_all([user_a_admin, user_a_pm, user_a_ph, user_b_admin, user_b_pm, user_b_ph])
         db.commit()
 
-        print("✅ Created 4 test users")
+        print("✅ Created 6 test users")
         print(f"   - {user_a_admin.name} ({user_a_admin.email}) - {user_a_admin.role}")
         print(f"   - {user_a_pm.name} ({user_a_pm.email}) - {user_a_pm.role}")
+        print(f"   - {user_a_ph.name} ({user_a_ph.email}) - {user_a_ph.role}")
         print(f"   - {user_b_admin.name} ({user_b_admin.email}) - {user_b_admin.role}")
         print(f"   - {user_b_pm.name} ({user_b_pm.email}) - {user_b_pm.role}")
+        print(f"   - {user_b_ph.name} ({user_b_ph.email}) - {user_b_ph.role}")
 
         print("\n✅ Test data seeded successfully!")
         print("\nYou can now run tests:")


### PR DESCRIPTION
## Summary

Fixes #148 by ensuring test database is properly seeded with all required users (including PROJECT_HANDLER role), eliminating foreign key violations that caused 107 test failures.

## Root Cause

The test suite was failing with `IntegrityError: Key (created_by)=(UUID) is not present in table "users"` because:

1. **pytest_sessionstart detection failed in CI**: The hook checked for `"qteria_test" in database_url`, but CI uses Neon PostgreSQL with "neondb" in the URL
2. **Missing PROJECT_HANDLER test users**: Seed data only created ADMIN and PROCESS_MANAGER users, but tests needed PROJECT_HANDLER
3. **Random UUIDs in fixtures**: `org_a_project_handler_token` generated random user_id not matching any database record

## Implementation

Follows approved plan from issue #148 comment (surgical fix, zero production code changes):

### 1. Fixed pytest_sessionstart Database Detection
- **Before**: `if "qteria_test" not in database_url: skip seeding`
- **After**: `if not ("qteria_test" in url or (CI and "neon.tech" in url)): skip`
- Correctly detects both local (`qteria_test`) and CI (Neon cloud) test databases

### 2. Added Fail-Fast Error Handling
- **Before**: Seeding failures printed warning, allowed 107 tests to fail cryptically
- **After**: `pytest.exit("Test data seeding failed")` stops all tests immediately with clear error
- Prevents cascade of confusing foreign key violations

### 3. Added PROJECT_HANDLER Test Users
New test user constants in `conftest.py`:
- `TEST_USER_A_PH_ID = "a4c2e8f0-1234-4a5b-9c8d-7e6f5a4b3c2d"` (Project Handler A)
- `TEST_USER_B_PH_ID = "b5d3f9e1-2345-5b6c-ad9e-8f7e6b5c4d3e"` (Project Handler B)

### 4. Updated Seed Script
- **Before**: Created 4 users (2 admins, 2 process managers)
- **After**: Creates 6 users (2 admins, 2 PMs, 2 project handlers)
- Imports new UUIDs from conftest, creates User records with PROJECT_HANDLER role

### 5. Fixed Token Fixtures
```python
# Before (used random UUID - not in DB):
org_a_project_handler_token() -> create_test_token(role=..., org_id=...)

# After (uses seeded user ID):
org_a_project_handler_token() -> create_test_token(
    user_id=TEST_USER_A_PH_ID,  # Fixed UUID that exists in DB
    role=PROJECT_HANDLER,
    organization_id=TEST_ORG_A_ID
)
```

Added `org_b_project_handler_token` fixture for symmetry and future multi-tenancy tests.

## Testing

### Local Verification
- [x] Seed script creates 6 users (2 orgs × 3 roles)
- [x] UUIDs in conftest match seeded database records
- [x] Idempotent seeding (script skips if data exists)
- [x] Workflow creation succeeds (no IntegrityError)
- [x] Black formatter passes

### CI Verification (Expected)
- [ ] pytest_sessionstart detects Neon test database (`CI=true + neon.tech in URL`)
- [ ] Seed hook output shows "Seeding test database" (not "Skipping")
- [ ] All 107 previously failing tests pass
- [ ] No `ForeignKeyViolation` errors in logs

## Breaking Changes

**None** - This is a test infrastructure fix with zero production code changes.

### Migration for Developers

If you have a local test database with old seed data:

```bash
# Clear old data and re-seed with new PROJECT_HANDLER users
cd apps/api
python scripts/clear_test_data.py
python scripts/seed_test_data.py

# Verify 6 users created
psql $DATABASE_URL -c "SELECT email, role FROM users;"
```

## Success Criteria

✅ **Primary:**
- All 107 previously failing tests pass in CI
- No `ForeignKeyViolation` errors in test logs
- pytest_sessionstart successfully seeds database (logs show "Seeding test database")

✅ **Code Quality:**
- Black formatter passes on all modified files
- No new linting errors introduced
- Clear comments explaining fixed UUIDs

✅ **Verification:**
- Seed script is idempotent (can run multiple times safely)
- Test database contains exactly 2 orgs + 6 users after seeding
- All 3 roles represented: ADMIN, PROCESS_MANAGER, PROJECT_HANDLER

## Files Changed

- `apps/api/tests/conftest.py` - Add PH user constants, fix detection logic, add token fixtures
- `apps/api/scripts/seed_test_data.py` - Add 2 PROJECT_HANDLER users, update docstring (4→6 users)

## Checklist

- [x] Implementation follows approved plan from issue #148
- [x] All tests passing locally (verified workflow creation works)
- [x] No backwards compatibility added (zero production changes)
- [x] Breaking changes documented (none - test-only)
- [x] Migration path clear (re-run seed script)
- [x] Code linted and type-checked (black passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)