### PR TITLE
fix: Suppress Redis connection errors in test environment (closes #174)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,10 +90,29 @@ DATABASE_URL=postgresql://...neon.tech/qteria_dev
 
 # .env.test (testing)
 DATABASE_URL=postgresql://...neon.tech/qteria_test
+PYTHON_ENV=test  # Suppresses Redis error logs in test output
 
 # Vercel environment variables (production)
 DATABASE_URL=postgresql://...neon.tech/qteria_prod
 ```
+
+### Redis in Tests
+
+Redis is **optional** in test environment. Tests will run without Redis, disabling:
+
+- Rate limiting (tests verify functionality, not limits)
+- Caching (tests use fresh data each time)
+
+In CI/local tests, Redis connection failures are suppressed (logged at DEBUG level instead of ERROR). This keeps test output clean while preserving production error visibility.
+
+**Environment Detection:**
+
+- Test mode: `PYTHON_ENV=test` OR pytest running → DEBUG level logs
+- Production/Dev: All other cases → ERROR level logs
+
+**Why This Matters:**
+
+Without this suppression, every test would show 50+ lines of Redis connection error logs, making it difficult to spot actual test failures. The application gracefully handles missing Redis by disabling rate limiting, so tests don't require Redis to run successfully.
 
 ### Quick Start
 


### PR DESCRIPTION
## Summary

Reduces test output noise by suppressing Redis connection error logs in test mode. Redis connection failures are now logged at DEBUG level (instead of ERROR) when running tests, making it easier to identify actual test failures.

## Changes

- **app/core/dependencies.py**: Added environment detection to suppress Redis errors in test mode
  - Import `sys` module for pytest detection
  - Detect test environment via `PYTHON_ENV=test` or `pytest in sys.modules`
  - Log Redis connection errors at DEBUG level in test mode
  - Preserve ERROR level logging in production/development environments
- **CLAUDE.md**: Added "Redis in Tests" documentation section
  - Explains Redis is optional in test environment
  - Documents environment detection logic
  - Clarifies why this matters (clean test output)

## Acceptance Criteria

- [x] Redis connection errors NOT logged at ERROR level when `PYTHON_ENV=test` or pytest is running
- [x] Test output clean - no Redis-related ERROR logs (verified manually)
- [x] Tests still pass without Redis running locally (graceful degradation preserved)
- [x] Production environment (`PYTHON_ENV=production`) still logs Redis errors at ERROR level
- [x] Development environment (`PYTHON_ENV=development`) still logs Redis errors at ERROR level
- [x] Documentation updated in CLAUDE.md explaining Redis is optional in tests

## Testing

Manual verification shows no Redis ERROR logs in test output when `PYTHON_ENV=test` is set. The application maintains graceful degradation - tests run successfully without Redis by disabling rate limiting.

## Benefits

**Before:**
- ❌ 50+ lines of Redis errors per test run
- ❌ Real failures buried in noise

**After:**
- ✅ Clean test output
- ✅ Easy to spot actual test failures
- ✅ Redis errors still visible in production

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>