### PR TITLE
Fix event listener memory leak in db_session fixture (closes #183)

### DIFF
--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -474,6 +474,8 @@ def db_session() -> Generator[Session, None, None]:
     # Cleanup: rollback all changes made during test
     # Use try/finally to ensure connection is always closed even if rollback fails
     try:
+        # Remove event listener to prevent accumulation in pytest watch mode
+        event.remove(session, "after_transaction_end", restart_savepoint)
         session.close()
         transaction.rollback()  # Rollback savepoint
         outer_transaction.rollback()  # Rollback outer transaction


### PR DESCRIPTION
## Summary

This PR fixes a minor memory leak in the test infrastructure where SQLAlchemy event listeners accumulate during pytest watch mode. The fix adds a single `event.remove()` call to properly clean up the `after_transaction_end` listener registered in the `db_session` fixture.

## Changes

- Added `event.remove(session, "after_transaction_end", restart_savepoint)` to cleanup block in `db_session` fixture (apps/api/tests/conftest.py:478)
- Added inline comment explaining the purpose of event removal
- Event listener signature matches `event.listens_for()` signature for proper cleanup

## Acceptance Criteria

- [x] `event.remove()` added to cleanup block before `session.close()`
- [x] Inline comment explains purpose: "Remove event listener to prevent accumulation in pytest watch mode"
- [x] Event.remove() signature matches event.listens_for() signature
- [ ] All existing tests pass (will be verified by CI)
- [x] Code follows project conventions

## Testing

This is a development experience improvement that prevents event listener accumulation in long-running pytest watch sessions (50+ iterations). The fix:

- ✅ CI is unaffected (each run uses a fresh process)
- ✅ Production is unaffected (test-only code)
- ✅ Prevents potential memory accumulation in pytest --watch mode
- ✅ Event.remove() is idempotent (safe to call even if listener already removed)

**Manual verification:**
- The existing test suite validates the fixture works correctly
- Event listener cleanup only affects long-running watch sessions (optional verification)

## Technical Details

**Event Listener Registration (line 466):**
```python
@event.listens_for(session, "after_transaction_end")
def restart_savepoint(session, transaction):
    ...
```

**Event Listener Removal (line 478):**
```python
event.remove(session, "after_transaction_end", restart_savepoint)
```

The signatures match exactly, ensuring proper cleanup. SQLAlchemy's `event.remove()` is idempotent and will not raise errors if the listener has already been removed.

## Priority

**P2 (Nice-to-have)** - This is technical debt cleanup, not a blocking bug. The test infrastructure works correctly; this just prevents potential developer experience issues in extended pytest watch sessions.

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>