### PR TITLE
Fix Prettier formatting in Claude command files (closes #196)

### DIFF
--- a/.claude/commands/coordinate.md
+++ b/.claude/commands/coordinate.md
@@ -59,6 +59,7 @@ gh issue view {issue-number} --repo bru-digital/qteria
 Create a mental map of which issues touch which files:
 
 Example analysis:
+
 - Issue #172: `models.py` (all models) - Low conflict risk (only this issue touches models)
 - Issue #173: `conftest.py` (lines 1-50) - Medium conflict risk (overlaps with #166)
 - Issue #166: `conftest.py` (lines 100+) - Medium conflict risk (overlaps with #173)

--- a/.claude/commands/plan-issue.md
+++ b/.claude/commands/plan-issue.md
@@ -700,6 +700,7 @@ EOF
 ```
 
 This ensures the plan is documented in the issue for:
+
 - Implementation agent reference
 - Team visibility and review
 - Audit trail of planning decisions


### PR DESCRIPTION
## Summary
Fixed Prettier formatting violations in two Claude command markdown files by running `npm run format`.

## Changes
- `.claude/commands/coordinate.md` - Added blank line after example list for proper markdown formatting
- `.claude/commands/plan-issue.md` - Added blank line after list item for proper markdown formatting

## Acceptance Criteria
- [x] Frontend lint passes (Prettier check) - Verified with `npm run format:check`
- [x] Both .md files formatted correctly - Applied Prettier auto-formatting
- [x] No content changes to files - Only whitespace/formatting adjustments
- [x] All tests pass - ESLint shows no warnings or errors
- [x] Code follows project conventions - Used project's Prettier configuration

## Testing
- Ran `npm run format` to auto-fix formatting violations
- Verified with `npm run format:check` - All files pass
- Verified with `npm run lint` - No ESLint warnings or errors
- Reviewed git diff to confirm only formatting changes (no content modifications)

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)