### PR TITLE
docs: Fix CI environment comment inconsistency in DATABASE_URL validation (closes #181)

### DIFF
--- a/apps/api/conftest.py
+++ b/apps/api/conftest.py
@@ -19,7 +19,7 @@ def _validate_test_database_url():
     Accepted patterns:
     - Database name contains 'qteria_test'
     - Database name ends with '_test'
-    - CI environment (CI=true) with neon.tech database
+    - CI environment (CI=true) with test database name
 
     Raises pytest.exit() if validation fails (fail-fast safety check).
     """
@@ -90,7 +90,7 @@ def _validate_test_database_url():
             f"Accepted patterns:\n"
             f"  - Database name contains 'qteria-test' or 'qteria_test'\n"
             f"  - Database name ends with '-test' or '_test'\n"
-            f"  - CI environment (CI=true) with neon.tech\n"
+            f"  - CI environment (CI=true) with test database name\n"
             f"\n"
             f"Fix: Update .env.test to point to test database:\n"
             f"  DATABASE_URL=postgresql://user:pass@host/qteria-test\n"


### PR DESCRIPTION
## Summary

Fixed documentation inconsistency in `apps/api/conftest.py` where comments mentioned "neon.tech database" requirement for CI environments, but the actual code only validates `CI=true` and test database name patterns.

## Changes

- **Line 22 (docstring)**: Changed `"CI environment (CI=true) with neon.tech database"` to `"CI environment (CI=true) with test database name"`
- **Line 93 (error message)**: Changed `"CI environment (CI=true) with neon.tech"` to `"CI environment (CI=true) with test database name"`

## Acceptance Criteria

- [x] Comment on line 22 updated to remove "with neon.tech database"
- [x] Error message on line 93 updated to remove "with neon.tech"
- [x] All comments accurately describe actual code behavior
- [x] No functional changes to validation logic
- [x] Existing tests pass without modification (documentation-only change)
- [ ] Code review confirms documentation matches implementation

## Testing

No new tests required. This is a documentation-only change that updates comments to match the existing validation logic in lines 64-70:

```python
is_ci = os.getenv("CI", "").lower() in ("true", "1", "yes")
is_ci_test = is_ci and (
    "qteria-test" in database_name.lower()
    or "qteria_test" in database_name.lower()
    or database_name.endswith("-test")
    or database_name.endswith("_test")
)
```

The code checks for:
1. `CI=true` environment variable
2. Test database name patterns

It does NOT check for `neon.tech` in the hostname, so the comments have been updated to reflect this reality.

## Related

- Implements code review recommendation from PR #176
- Priority: P2 (nice-to-have documentation improvement)

Closes #181

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)