### PR TITLE
Fix invalid UUID generation in assessment API test (closes #209)

### DIFF
--- a/apps/api/tests/test_assessments_api.py
+++ b/apps/api/tests/test_assessments_api.py
@@ -291,6 +291,13 @@ class TestStartAssessment:
             client, org_a_process_manager_token
         )
 
+        # Define valid UUIDs for each role (hex-only characters)
+        document_ids = {
+            "admin": "550e8400-e29b-41d4-a716-446655440001",
+            "process_manager": "550e8400-e29b-41d4-a716-446655440002",
+            "project_handler": "550e8400-e29b-41d4-a716-446655440003",
+        }
+
         # Test each role
         for role_name, token in [
             ("admin", org_a_admin_token),
@@ -302,7 +309,7 @@ class TestStartAssessment:
                 "documents": [
                     {
                         "bucket_id": required_bucket_id,
-                        "document_id": f"550e8400-e29b-41d4-a716-44665544{role_name[:4]}",
+                        "document_id": document_ids[role_name],
                         "file_name": f"{role_name}-document.pdf",
                         "storage_key": f"https://blob.vercel-storage.com/{role_name}.pdf",
                         "file_size": 1024,


### PR DESCRIPTION
## Summary

Fix the invalid UUID generation in `test_start_assessment_all_roles_allowed` that was causing HTTP 422 validation errors. The test was generating UUIDs by concatenating role names to a UUID prefix, which produced invalid UUIDs containing non-hex characters.

## Changes

- **File**: `apps/api/tests/test_assessments_api.py`
- **Change**: Replaced dynamic UUID generation with predefined valid UUIDs

**Before (line 305)**:
```python
"document_id": f"550e8400-e29b-41d4-a716-44665544{role_name[:4]}",
```

This generated invalid UUIDs:
- `admin` → `550e8400-e29b-41d4-a716-44665544admi` (contains non-hex: d, m, i)
- `process_manager` → `550e8400-e29b-41d4-a716-44665544proc` (contains non-hex: p, r, o)
- `project_handler` → `550e8400-e29b-41d4-a716-44665544proj` (contains non-hex: p, r, o, j)

**After (lines 294-312)**:
```python
# Define valid UUIDs for each role (hex-only characters)
document_ids = {
    "admin": "550e8400-e29b-41d4-a716-446655440001",
    "process_manager": "550e8400-e29b-41d4-a716-446655440002",
    "project_handler": "550e8400-e29b-41d4-a716-446655440003",
}

# Use predefined UUID
"document_id": document_ids[role_name],
```

## Acceptance Criteria

- ✅ Line 305 no longer generates UUIDs with non-hex characters
- ✅ UUIDs are valid RFC 4122 format (verified with Python uuid.UUID())
- ✅ Test syntax is correct (verified with py_compile)
- ✅ Code passes linting (verified with ruff)
- ✅ Pre-commit hooks pass
- ✅ All UUIDs are unique for each role iteration

## Testing

**Validation performed:**

1. **UUID Validity Check**: Confirmed new UUIDs are valid RFC 4122 format
   ```python
   uuid.UUID("550e8400-e29b-41d4-a716-446655440001")  # ✓ Valid
   uuid.UUID("550e8400-e29b-41d4-a716-446655440002")  # ✓ Valid
   uuid.UUID("550e8400-e29b-41d4-a716-446655440003")  # ✓ Valid
   ```

2. **Old UUIDs Invalid Check**: Confirmed old UUIDs were invalid
   ```python
   uuid.UUID("550e8400-e29b-41d4-a716-44665544admi")   # ✗ ValueError
   uuid.UUID("550e8400-e29b-41d4-a716-44665544proc")   # ✗ ValueError
   uuid.UUID("550e8400-e29b-41d4-a716-44665544proj")   # ✗ ValueError
   ```

3. **Syntax Check**: Python compilation successful
4. **Linting**: Ruff linting passed with no issues
5. **Pre-commit Hooks**: All hooks passed (Black, Ruff, trailing whitespace, etc.)

**Why tests couldn't run:**
The test database is not properly configured (DATABASE_URL in .env.test points to "neondb" instead of "qteria-test"). This is a separate infrastructure issue tracked in the backlog. The fix itself is verified through:
- UUID validation (confirms valid format)
- Syntax checking (confirms no Python errors)
- Linting (confirms code quality)

The CI pipeline will run the full test suite and verify the fix works end-to-end.

## Impact

- **Risk**: Low - Only changes test data generation, no production code affected
- **Scope**: Single test function in test file
- **Dependencies**: None - self-contained change

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)