### PR TITLE
[URGENT] Re-skip test_validate_rejects_neondb to prevent CI contamination (closes #242)

### DIFF
--- a/apps/api/tests/test_conftest.py
+++ b/apps/api/tests/test_conftest.py
@@ -73,6 +73,9 @@ def test_validate_accepts_qteria_test_uppercase(monkeypatch):
 
 
 @pytest.mark.unit
+@pytest.mark.skip(
+    reason="Test triggers pytest.exit() which interferes with cleanup - see issue #242"
+)
 def test_validate_rejects_neondb(monkeypatch):
     """Test that production database name 'neondb' triggers pytest.exit() with appropriate error."""
     monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@host/neondb")


### PR DESCRIPTION
## Summary

This PR re-adds the `@pytest.mark.skip` decorator to `test_validate_rejects_neondb` which was inadvertently removed in PR #240. The test causes environment contamination even with monkeypatch due to `pytest.exit()` interfering with cleanup.

## Problem

PR #240 replaced `patch.dict()` with `monkeypatch` to fix environment contamination issues. However, it also removed the skip decorator from `test_validate_rejects_neondb`, causing CI failures with DATABASE_URL contamination showing `neondb` after tests complete.

## Solution

**Immediate Fix (This PR):**
- Re-added `@pytest.mark.skip` decorator with updated reason
- Test remains skipped until proper subprocess isolation is implemented

**Long-term Fix:**
- Move validation tests to subprocess isolation (tracked in issue #237)
- This will allow the test to run without contaminating the main process

## Changes
- Added `@pytest.mark.skip` decorator to `test_validate_rejects_neondb`
- Updated skip reason to reference issue #242

## Acceptance Criteria
- [x] `test_validate_rejects_neondb` is skipped again
- [x] Pre-commit hooks pass (Black formatting applied)
- [ ] CI passes without DATABASE_URL contamination
- [x] Documentation in skip reason explains why test must remain skipped

## Testing
- Verified skip decorator is properly formatted by Black
- Test shows as skipped when running test suite
- No environment contamination expected in CI

## Priority

**P0 - CRITICAL**: This is blocking all PRs from merging due to CI failures

## Related

- PR #240 - Monkeypatch implementation that needs this fix
- Issue #237 - Long-term solution with subprocess isolation  
- Issue #215 - Original contamination issue

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>